### PR TITLE
Bug fix: Getting events for a single day (e. g. "Get all my events for today")

### DIFF
--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -191,7 +191,6 @@ export class GoogleCalendarService {
 		if (startDate === endDate) {
 			endDate = endDate + "T23:59:59";
 		}
-		console.log(startDate + "-" + endDate);
 		const res = await calendar.events.list({
 			calendarId,
 			timeMin: new Date(startDate).toISOString(),

--- a/src/services/google-calendar.ts
+++ b/src/services/google-calendar.ts
@@ -188,7 +188,10 @@ export class GoogleCalendarService {
 	): Promise<GoogleCalendarEventList> {
 		const auth = await this.authorize();
 		const calendar = google.calendar({ version: "v3", auth });
-
+		if (startDate === endDate) {
+			endDate = endDate + "T23:59:59";
+		}
+		console.log(startDate + "-" + endDate);
 		const res = await calendar.events.list({
 			calendarId,
 			timeMin: new Date(startDate).toISOString(),


### PR DESCRIPTION
"Get all my events for today" lead to the following MCP request:
```
Request:
calendarId: "xxx"
startsAt: "2025-07-04" 
endsAt: "2025-07-04"

Response:
"items": []
```
Qick and dirty fix attempt by setting endDate to 23:59:59 on that day.